### PR TITLE
Add Configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,51 +3,51 @@ sudo: required
 dist: trusty
 os: linux
 python:
-    - "3.6"
+  - "3.6"
 
 services:
-    - docker
+  - docker
 
 git:
-    depth: false  # Ensure latest tag is pulled
+  depth: false  # Ensure latest tag is pulled
 
 branches:
-    only:
-        - master
+  only:
+    - master
 
 jobs:
-    fast_finish: true
+  fast_finish: true
 
-    include:
-        - env:
-            - CLUSTER_TYPE=kerberos
-            - PYTHON=3.6
-        - env:
-            - CLUSTER_TYPE=base
-            - PYTHON=2.7
+  include:
+    - env:
+      - CLUSTER_TYPE=kerberos
+      - PYTHON=3.6
+    - env:
+      - CLUSTER_TYPE=base
+      - PYTHON=2.7
 
 before_install:
-    # Upgrade docker-compose
-    - sudo rm /usr/local/bin/docker-compose
-    - curl -L https://github.com/docker/compose/releases/download/1.19.0/docker-compose-`uname -s`-`uname -m` > docker-compose
-    - chmod +x docker-compose
-    - sudo mv docker-compose /usr/local/bin
+  # Upgrade docker-compose
+  - sudo rm /usr/local/bin/docker-compose
+  - curl -L https://github.com/docker/compose/releases/download/1.19.0/docker-compose-`uname -s`-`uname -m` > docker-compose
+  - chmod +x docker-compose
+  - sudo mv docker-compose /usr/local/bin
     # Install the test cluster
-    - pip install git+https://github.com/jcrist/hadoop-test-cluster.git
+  - pip install git+https://github.com/jcrist/hadoop-test-cluster.git
     # Start the test cluster
-    - htcluster startup --image $CLUSTER_TYPE:latest --mount .:dask-yarn
+  - htcluster startup --image $CLUSTER_TYPE:latest --mount .:dask-yarn
 
 install:
-    - htcluster exec -- ./dask-yarn/continuous_integration/travis/install.sh $PYTHON
+  - htcluster exec -- ./dask-yarn/continuous_integration/travis/install.sh $PYTHON
 
 script:
-    - set -e
-    - export CONDA_ENV=/home/testuser/miniconda/envs/test-environment
-    - |
-      if [[ "$CLUSTER_TYPE" == "kerberos" ]]; then
-        htcluster exec -- kinit testuser -kt testuser.keytab
-      fi
-    - htcluster exec -- ./dask-yarn/continuous_integration/travis/run-tests.sh
+  - set -e
+  - export CONDA_ENV=/home/testuser/miniconda/envs/test-environment
+  - |
+    if [[ "$CLUSTER_TYPE" == "kerberos" ]]; then
+    htcluster exec -- kinit testuser -kt testuser.keytab
+    fi
+  - htcluster exec -- ./dask-yarn/continuous_integration/travis/run-tests.sh
 
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ script:
   - export CONDA_ENV=/home/testuser/miniconda/envs/test-environment
   - |
     if [[ "$CLUSTER_TYPE" == "kerberos" ]]; then
-    htcluster exec -- kinit testuser -kt testuser.keytab
+      htcluster exec -- kinit testuser -kt testuser.keytab
     fi
   - htcluster exec -- ./dask-yarn/continuous_integration/travis/run-tests.sh
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -8,5 +8,3 @@ include requirements.txt
 
 recursive-exclude * __pycache__
 recursive-exclude * *.py[co]
-include versioneer.py
-include dask_yarn/_version.py

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,12 @@
+recursive-include dask_yarn *.py
+recursive-include dask_yarn *.yaml
+
+include LICENSE.txt
+include README.rst
+
+include requirements.txt
+
+recursive-exclude * __pycache__
+recursive-exclude * *.py[co]
+include versioneer.py
+include dask_yarn/_version.py

--- a/dask_yarn/__init__.py
+++ b/dask_yarn/__init__.py
@@ -4,4 +4,4 @@ from __future__ import absolute_import, print_function, division
 from . import _patch
 del _patch
 
-from .core import YarnCluster, make_remote_spec
+from .core import YarnCluster, make_specification

--- a/dask_yarn/__init__.py
+++ b/dask_yarn/__init__.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import, print_function, division
 
 # Patch old versions of dask before importing anything else
 from . import _patch
-del _patch
+from . import config
+del _patch, config
 
 from .core import YarnCluster, make_specification

--- a/dask_yarn/config.py
+++ b/dask_yarn/config.py
@@ -1,0 +1,15 @@
+from __future__ import print_function, division, absolute_import
+
+import os
+
+import dask
+import yaml
+
+
+fn = os.path.join(os.path.dirname(__file__), 'yarn.yaml')
+dask.config.ensure_file(source=fn)
+
+with open(fn) as f:
+    defaults = yaml.load(f)
+
+dask.config.update_defaults(defaults)

--- a/dask_yarn/core.py
+++ b/dask_yarn/core.py
@@ -8,11 +8,13 @@ from distributed.utils import format_bytes, PeriodicCallback, log_errors
 import skein
 
 
-def make_remote_spec(environment, name='dask', queue='default', tags=None,
-                     n_workers=0, worker_vcores=1, worker_memory=2048,
-                     worker_max_restarts=-1, scheduler_vcores=1,
-                     scheduler_memory=2048):
-    """Create a ``skein.ApplicationSpec`` to run a dask cluster with the
+def make_specification(environment, name='dask', queue='default', tags=None,
+                       n_workers=0, worker_vcores=1, worker_memory=2048,
+                       worker_max_restarts=-1, scheduler_vcores=1,
+                       scheduler_memory=2048):
+    """ Create specification to run Dask Cluster
+
+    This creates a ``skein.ApplicationSpec`` to run a dask cluster with the
     scheduler in a YARN container.
 
     Parameters
@@ -73,15 +75,22 @@ def make_remote_spec(environment, name='dask', queue='default', tags=None,
 
 @skein.utils.with_finalizers
 class YarnCluster(object):
-    """Start a Dask cluster on YARN.
+    """ Start a Dask cluster on YARN.
 
     Parameters
     ----------
-    spec : skein.ApplicationSpec
+    spec : skein.ApplicationSpec, dict, or filename
         The application specification to use. Should define at least two
         services: ``'dask.scheduler'`` and ``'dask.worker'``.
+        See ``make_specification`` for more details
     skein_client : skein.Client, optional
         The ``skein.Client`` to use. If not provided, one will be started.
+
+    Examples
+    --------
+    >>> spec = dask_yarn.make_specification('my-env.tar.gz', ...)
+    >>> cluster = YarnCluster(spec)
+    >>> cluster.scale(10)
     """
     def __init__(self, spec, skein_client=None):
         if skein_client is None:

--- a/dask_yarn/core.py
+++ b/dask_yarn/core.py
@@ -13,7 +13,7 @@ memory_warning = """
 The memory keywords takes string parameters
 that include units like "4 GiB" or "2048 MB"
 
-You provided: %d
+You provided:       %d
 Perhaps you meant: "%d MB"
 """
 
@@ -149,6 +149,8 @@ class YarnCluster(object):
         See ``make_specification`` for more details
     skein_client : skein.Client, optional
         The ``skein.Client`` to use. If not provided, one will be started.
+    **kwargs:
+        Extra keyword arguments to pass to make_specification if necessary
 
     Examples
     --------
@@ -161,6 +163,10 @@ class YarnCluster(object):
             spec = dask.config.get('yarn.specification')
         if spec is None:
             spec = make_specification(**kwargs)
+        else:
+            if kwargs:
+                raise ValueError("A full specification was found "
+                                 "so keyword arguments were not used")
         if skein_client is None:
             skein_client = skein.Client()
 

--- a/dask_yarn/tests/test_core.py
+++ b/dask_yarn/tests/test_core.py
@@ -1,5 +1,6 @@
 import conda_pack
 
+import dask
 import dask_yarn
 from dask_yarn import YarnCluster
 from dask.distributed import Client
@@ -23,7 +24,8 @@ def env():
 
 @pytest.fixture(scope='module')
 def spec(env):
-    spec = dask_yarn.make_specification(env, worker_memory=1024, scheduler_memory=1024)
+    spec = dask_yarn.make_specification(env, worker_memory='1024 MB',
+                                        scheduler_memory='1024 MB')
     return spec
 
 
@@ -67,3 +69,57 @@ def test_yaml_file(loop, spec, clean, tmpdir):  # noqa F811
     with YarnCluster(fn) as cluster:
         with Client(cluster, loop=loop):
             pass
+
+
+def test_config_spec(spec, loop):  # noqa F811
+    with dask.config.set({'yarn': {'specification': spec.to_dict()}}):
+        with YarnCluster() as cluster:
+            with Client(cluster, loop=loop):
+                pass
+
+
+def test_config_env(loop, env):  # noqa F811
+    config = {'yarn': {
+        'environment': env,
+        'queue': 'q-123',
+        'name': 'dask-name-123',
+        'tags': ['a', 'b', 'c'],
+        'specification': None,
+        'workers': {'memory': '1234MB', 'instances': 1, 'vcores': 1, 'restarts': -1},
+        'scheduler': {'memory': '1234MB', 'vcores': 1}}
+    }
+
+    with dask.config.set(config):
+        spec = dask_yarn.make_specification()
+        assert 'dask-name-123' in str(spec.to_dict())
+        assert 'q-123' in str(spec.to_dict())
+        with YarnCluster() as cluster:
+            with Client(cluster, loop=loop) as client:
+                client.submit(lambda: 0).result()  # wait for a worker
+
+                info = client.scheduler_info()
+                assert len(info['workers']) == 1
+                [w] = info['workers'].values()
+                assert w['memory_limit'] == 1234e6
+
+
+def test_config_errors():
+    with dask.config.set({'yarn.environment': None}):
+        with pytest.raises(ValueError) as info:
+            dask_yarn.make_specification()
+
+        assert all(word in str(info.value)
+                   for word in
+                   ['redeployable', 'conda-pack', 'dask-yarn.readthedocs.org'])
+
+    with pytest.raises(ValueError) as info:
+        dask_yarn.make_specification(environment='foo.tar.gz',
+                                     worker_memory=1234)
+
+        assert '1234 MB' in str(info.value)
+
+    with pytest.raises(ValueError) as info:
+        dask_yarn.make_specification(environment='foo.tar.gz',
+                                     scheduler_memory=1234)
+
+        assert '1234 MB' in str(info.value)

--- a/dask_yarn/tests/test_core.py
+++ b/dask_yarn/tests/test_core.py
@@ -23,7 +23,7 @@ def env():
 
 @pytest.fixture(scope='module')
 def spec(env):
-    spec = dask_yarn.make_remote_spec(env, worker_memory=1024, scheduler_memory=1024)
+    spec = dask_yarn.make_specification(env, worker_memory=1024, scheduler_memory=1024)
     return spec
 
 

--- a/dask_yarn/tests/test_core.py
+++ b/dask_yarn/tests/test_core.py
@@ -103,6 +103,19 @@ def test_config_env(loop, env):  # noqa F811
                 assert w['memory_limit'] == 1234e6
 
 
+def test_constructor_keyword_arguments(loop, env, spec):  # noqa F811
+    with YarnCluster(environment=env) as cluster:
+        with Client(cluster, loop=loop):
+            pass
+
+    with pytest.raises(ValueError) as info:
+        with YarnCluster(spec, environment=env):
+            pass
+
+    assert "keyword" in str(info.value)
+    assert "not used" in str(info.value)
+
+
 def test_config_errors():
     with dask.config.set({'yarn.environment': None}):
         with pytest.raises(ValueError) as info:

--- a/dask_yarn/yarn.yaml
+++ b/dask_yarn/yarn.yaml
@@ -1,0 +1,17 @@
+yarn:
+  specification: null        # A full Skein specification
+                             # or path to a specification yaml file
+                             # Overwrites the following configuraiton if given
+
+  name: dask                 # Application name
+  queue: default             # Yarn queue to deploy to
+  environment: null          # Path to conda packed environment
+  tags: []                   # List of strings to tag applications
+  scheduler:                 # Specifications of scheduler container
+    vcores: 1
+    memory: 2GiB
+  workers:                   # Specifications of worker containers
+    vcores: 1
+    memory: 2GiB
+    instances: 0
+    restarts: -1             # Allowed number of restarts, -1 for unlimited

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+dask >=0.18.0
+distributed>=1.22.0
+skein

--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,7 @@ setup(name='dask-yarn',
       license='BSD',
       description='Deploy dask clusters on Apache YARN',
       packages=['dask_yarn', 'dask_yarn.cli'],
+      include_package_data=True,
       install_requires=['distributed', 'skein'],
       entry_points='''
         [console_scripts]

--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,15 @@
 from setuptools import setup
 
+with open('requirements.txt') as f:
+    install_requires = f.read().strip().split('\n')
+
 setup(name='dask-yarn',
       version='0.0.1',
       license='BSD',
       description='Deploy dask clusters on Apache YARN',
       packages=['dask_yarn', 'dask_yarn.cli'],
       include_package_data=True,
-      install_requires=['distributed', 'skein'],
+      install_requires=install_requires,
       entry_points='''
         [console_scripts]
         dask-yarn-worker=dask_yarn.cli.dask_yarn_worker:main


### PR DESCRIPTION
This adds a basic config file and uses that configuration throughout the
dask-yarn codebase.

This also switches the convention away from providing memory size in
megabytes and instead using strings with units.  We provide informative
error messages to guide users to correct behavior.

cc @jcrist for review.  In particular I want to check in and make sure that you're ok with the memory handling conventions.  They're different from skein.  We can walk back from this a bit if you like.