### PR TITLE
Many changes

### DIFF
--- a/dask_yarn/__init__.py
+++ b/dask_yarn/__init__.py
@@ -5,4 +5,4 @@ from . import _patch
 from . import config
 del _patch, config
 
-from .core import YarnCluster, make_specification
+from .core import YarnCluster

--- a/dask_yarn/core.py
+++ b/dask_yarn/core.py
@@ -90,11 +90,11 @@ def make_specification(
         scheduler_memory = dask.config.get('yarn.scheduler.memory')
 
     if environment is None:
-        msg = ("You must provide a path to a redeployable environment for the "
-               "workers.\n"
+        msg = ("You must provide a path to an archived python environment for "
+               "the workers.\n"
                "This is commonly achieved through conda-pack.\n\n"
-               "See https://dask-yarn.readthedocs.org/en/latest/environments.html "
-               "for more information")
+               "See https://dask-yarn.readthedocs.io/en/latest/"
+               "#distributing-python-environments for more information")
         raise ValueError(msg)
 
     environment = os.path.abspath(environment)

--- a/dask_yarn/yarn.yaml
+++ b/dask_yarn/yarn.yaml
@@ -1,17 +1,19 @@
 yarn:
-  specification: null        # A full Skein specification
-                             # or path to a specification yaml file
-                             # Overwrites the following configuraiton if given
+  specification: null        # A full Skein specification or path to a
+                             # specification yaml file. Overrides the following
+                             # configuration if given
 
   name: dask                 # Application name
   queue: default             # Yarn queue to deploy to
   environment: null          # Path to conda packed environment
   tags: []                   # List of strings to tag applications
+
   scheduler:                 # Specifications of scheduler container
     vcores: 1
     memory: 2GiB
-  workers:                   # Specifications of worker containers
+
+  worker:                   # Specifications of worker containers
     vcores: 1
     memory: 2GiB
-    instances: 0
-    restarts: -1             # Allowed number of restarts, -1 for unlimited
+    count: 0                # Number of workers to start on initialization
+    restarts: -1            # Allowed number of restarts, -1 for unlimited

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -88,13 +88,15 @@ example:
      environment: /path/to/my-env.tar.gz
 
      tags: []                   # List of strings to tag applications
+
      scheduler:                 # Specifications of scheduler container
        vcores: 1
        memory: 4GiB
-     workers:                   # Specifications of worker containers
+
+     worker:                   # Specifications of worker containers
        vcores: 2
        memory: 8GiB
-       instances: 0             # Number of default workers with which to start
+       count: 0                 # Number of workers to start on initialization
        restarts: -1             # Allowed number of restarts, -1 for unlimited
 
 Users can now create YarnClusters without specifying any additional

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 dask >=0.18.0
 distributed>=1.22.0
 skein
+backports.weakref;python_version<="3.4"


### PR DESCRIPTION
- Cleanup tests
- Remove `make_specification` in favor of just using constructor
- Add `from_specification`
- Use `backports.finalize` for py27
- Explicitly shutdown cluster instead of killing