### PR TITLE
Fixups and update for new skein release

### DIFF
--- a/continuous_integration/travis/install.sh
+++ b/continuous_integration/travis/install.sh
@@ -18,6 +18,10 @@ source activate test-environment
 
 pip install grpcio-tools conda-pack 
 
+if [[ $1 == '2.7' ]]; then
+    pip install backports.weakref
+fi
+
 pip install git+https://github.com/jcrist/skein
 
 cd ~/dask-yarn

--- a/continuous_integration/travis/install.sh
+++ b/continuous_integration/travis/install.sh
@@ -20,8 +20,6 @@ pip install grpcio-tools conda-pack
 
 pip install git+https://github.com/jcrist/skein
 
-skein init
-
 cd ~/dask-yarn
 pip install -v --no-deps .
 

--- a/dask_yarn/cli/dask_yarn_scheduler.py
+++ b/dask_yarn/cli/dask_yarn_scheduler.py
@@ -45,14 +45,14 @@ def main():
 
     install_signal_handlers(loop)
 
-    app_client.kv['dask.scheduler'] = scheduler.address
+    app_client.kv['dask.scheduler'] = scheduler.address.encode()
 
     if bokeh:
         bokeh_port = scheduler.services['bokeh'].port
         bokeh_host = urlparse(scheduler.address).hostname
         bokeh_address = 'http://%s:%d' % (bokeh_host, bokeh_port)
 
-        app_client.kv['dask.dashboard'] = bokeh_address
+        app_client.kv['dask.dashboard'] = bokeh_address.encode()
 
     try:
         loop.start()

--- a/dask_yarn/tests/test_core.py
+++ b/dask_yarn/tests/test_core.py
@@ -33,12 +33,12 @@ def skein_client():
 
 def check_is_shutdown(client, app_id, status='SUCCEEDED'):
     timeleft = 5
-    report = client.status(app_id)
+    report = client.application_report(app_id)
     while report.state not in ('FINISHED', 'FAILED', 'KILLED'):
         time.sleep(0.1)
         timeleft -= 0.1
         if timeleft < 0:
-            client.kill(app_id)
+            client.kill_application(app_id)
             assert False, "Application wasn't properly terminated"
 
     assert report.final_status == status

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-dask >=0.18.0
+dask>=0.18.0
 distributed>=1.22.0
-skein
+skein>=0.1.0
 backports.weakref;python_version<="3.4"


### PR DESCRIPTION
- Correctly forward `worker_restarts` to specification (Fixes #13)
- Don't set `DASK_CONFIG` on containers (Fixes #12)
- Update to support new skein release (backwards incompatible changes).