### PR TITLE
Add `worker_env`

### DIFF
--- a/continuous_integration/travis/install.sh
+++ b/continuous_integration/travis/install.sh
@@ -8,6 +8,7 @@ conda create -n test-environment \
     dask \
     distributed \
     flake8 \
+    protobuf \
     grpcio \
     nomkl \
     pytest \

--- a/continuous_integration/travis/install.sh
+++ b/continuous_integration/travis/install.sh
@@ -16,13 +16,14 @@ conda create -n test-environment \
 
 source activate test-environment
 
-pip install grpcio-tools conda-pack 
+pip install conda-pack 
+pip install --no-deps grpcio-tools
 
 if [[ $1 == '2.7' ]]; then
     pip install backports.weakref
 fi
 
-pip install git+https://github.com/jcrist/skein
+pip install --no-deps git+https://github.com/jcrist/skein
 
 cd ~/dask-yarn
 pip install -v --no-deps .

--- a/dask_yarn/core.py
+++ b/dask_yarn/core.py
@@ -53,6 +53,7 @@ def _make_specification(**kwargs):
     worker_vcores = either('worker_vcores', 'yarn.worker.vcores')
     worker_memory = either('worker_memory', 'yarn.worker.memory')
     worker_restarts = either('worker_restarts', 'yarn.worker.restarts')
+    worker_env = either('worker_env', 'yarn.worker.env')
     scheduler_vcores = either('scheduler_vcores', 'yarn.scheduler.vcores')
     scheduler_memory = either('scheduler_memory', 'yarn.scheduler.memory')
 
@@ -94,6 +95,7 @@ def _make_specification(**kwargs):
                            max_restarts=worker_restarts,
                            depends=['dask.scheduler'],
                            files={'environment': environment},
+                           env=worker_env,
                            commands=['source environment/bin/activate',
                                      'dask-yarn-worker'])
 
@@ -126,6 +128,9 @@ class YarnCluster(object):
     worker_restarts : int, optional
         The maximum number of worker restarts to allow before failing the
         application. Default is unlimited.
+    worker_env : dict, optional
+        A mapping of environment variables to their values. These will be set
+        in the worker containers before starting the dask workers.
     scheduler_vcores : int, optional
         The number of virtual cores to allocate per scheduler.
     scheduler_memory : str, optional
@@ -151,6 +156,7 @@ class YarnCluster(object):
                  worker_vcores=None,
                  worker_memory=None,
                  worker_restarts=None,
+                 worker_env=None,
                  scheduler_vcores=None,
                  scheduler_memory=None,
                  name=None,
@@ -163,6 +169,7 @@ class YarnCluster(object):
                                    worker_vcores=worker_vcores,
                                    worker_memory=worker_memory,
                                    worker_restarts=worker_restarts,
+                                   worker_env=worker_env,
                                    scheduler_vcores=scheduler_vcores,
                                    scheduler_memory=scheduler_memory,
                                    name=name,

--- a/dask_yarn/tests/test_core.py
+++ b/dask_yarn/tests/test_core.py
@@ -88,7 +88,8 @@ def test_configuration():
         'name': 'dask-yarn-tests',
         'tags': ['a', 'b', 'c'],
         'specification': None,
-        'worker': {'memory': '1234MB', 'count': 1, 'vcores': 1, 'restarts': -1},
+        'worker': {'memory': '1234MB', 'count': 1, 'vcores': 1, 'restarts': -1,
+                   'env': {'foo': 'bar'}},
         'scheduler': {'memory': '1234MB', 'vcores': 1}}
     }
 
@@ -98,6 +99,7 @@ def test_configuration():
         assert spec.queue == 'myqueue'
         assert spec.tags == {'a', 'b', 'c'}
         assert spec.services['dask.worker'].resources.memory == 1234
+        assert spec.services['dask.worker'].env == {'foo': 'bar'}
         assert spec.services['dask.scheduler'].resources.memory == 1234
 
 

--- a/dask_yarn/yarn.yaml
+++ b/dask_yarn/yarn.yaml
@@ -17,3 +17,4 @@ yarn:
     memory: 2GiB
     count: 0                # Number of workers to start on initialization
     restarts: -1            # Allowed number of restarts, -1 for unlimited
+    env: {}                 # A map of environment variables to set on the worker


### PR DESCRIPTION
Supports setting environment variables on the worker containers.