### PR TITLE
Add venv-pack to docs

### DIFF
--- a/dask_yarn/core.py
+++ b/dask_yarn/core.py
@@ -58,9 +58,9 @@ def _make_specification(**kwargs):
     scheduler_memory = either('scheduler_memory', 'yarn.scheduler.memory')
 
     if environment is None:
-        msg = ("You must provide a path to an archived python environment for "
+        msg = ("You must provide a path to an archived Python environment for "
                "the workers.\n"
-               "This is commonly achieved through conda-pack.\n\n"
+               "This is commonly achieved through conda-pack or venv-pack.\n\n"
                "See https://dask-yarn.readthedocs.io/en/latest/"
                "#distributing-python-environments for more information")
         raise ValueError(msg)
@@ -117,7 +117,7 @@ class YarnCluster(object):
     Parameters
     ----------
     environment : str, optional
-        Path to an archived Conda environment (either ``tar.gz`` or ``zip``).
+        Path to an archived Python environment (either ``tar.gz`` or ``zip``).
     n_workers : int, optional
         The number of workers to initially start.
     worker_vcores : int, optional

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -54,12 +54,21 @@ Distributing Python Environments
 --------------------------------
 
 We need to ensure that the libraries used on the Yarn cluster are the same as
-what you are using locally.  We accomplish this by packaging up a conda
-environment with `conda-pack <https://conda.github.io/conda-pack/>`__ and
-shipping it to the Yarn cluster with Dask-Yarn.
+what you are using locally. By default, ``dask-yarn`` handles this by
+distributing a packaged python environment to the Yarn cluster as part of the
+applications. This is typically handled using
+
+- conda-pack_ for Conda_ environments
+- venv-pack_  for `virtual environments`_
 
 These environments can contain any Python packages you might need, but require
 ``dask-yarn`` (and its dependencies) at a minimum.
+
+
+Packing Conda Environments using Conda-Pack
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+You can package a conda environment using conda-pack_.
 
 .. code-block:: console
 
@@ -72,9 +81,39 @@ These environments can contain any Python packages you might need, but require
     Packing environment at '/home/username/miniconda/envs/my-env' to 'my-env.tar.gz'
     [########################################] | 100% Completed |  12.2s
 
-You can now start a cluster with that environment by passing the path to the
-constructor, e.g. ``YarnCluster(environment='my-env.tar.gz', ...)``.  You may
-want to verify that your versions match with the following:
+
+Packing Virtual Environments using Venv-Pack
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+You can package a virtual environment using venv-pack_. The virtual environment
+can be created using either venv_ or virtualenv_. Note that the python linked
+to in the virtual environment must exist and be accessible on every node in the
+YARN cluster. If the environment was created with a different Python, you can
+change the link path using the ``--python-prefix`` flag. For more information see
+the `venv-pack documentation`_.
+
+.. code-block:: console
+
+    $ python -m venv my_env                     # Create an environment using venv
+    $ python -m virtualenv my_env               # Or create an environment using virtualenv
+
+    $ source my_env/bin/activate                # Activate the environment
+
+    $ pip install dask-yarn scikit-learn        # Install some packages
+
+    $ venv-pack                                 # Package environment
+    Collecting packages...
+    Packing environment at '/home/username/my-env' to 'my-env.tar.gz'
+    [########################################] | 100% Completed |  8.3s
+
+
+Specifying the Environment for the Cluster
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+You can now start a cluster with the packaged environment by passing the
+path to the constructor, e.g. ``YarnCluster(environment='my-env.tar.gz',
+...)``. After startup you may want to verify that your versions match with the
+following:
 
 .. code-block:: python
 
@@ -84,6 +123,15 @@ want to verify that your versions match with the following:
    cluster = YarnCluster(environment='my-env.tar.gz')
    client = Client(cluster)
    client.get_versions(check=True)  # check that versions match between all nodes
+
+.. _conda-pack: https://conda.github.io/conda-pack/
+.. _conda: http://conda.io/
+.. _venv:
+.. _virtual environments: https://docs.python.org/3/library/venv.html
+.. _virtualenv: https://virtualenv.pypa.io/en/stable/
+.. _venv-pack documentation:
+.. _venv-pack: https://jcrist.github.io/venv-pack/
+
 
 Configuration
 -------------


### PR DESCRIPTION
Document how to package and deploy dask using virtualenvs in addition
to conda environments.

Fixes #18.