### PR TITLE
Add `from_current` and `from_application_id`

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,5 @@
+[run]
+include = */dask_yarn/*
+omit =
+    dask_yarn/_version.py
+    dask_yarn/tests/*.py

--- a/dask_yarn/tests/test_core.py
+++ b/dask_yarn/tests/test_core.py
@@ -1,18 +1,17 @@
 import os
-import time
+import shutil
 import sys
+import time
 
 import conda_pack
 import dask
 from dask.distributed import Client
-from distributed.utils_test import loop, inc
+from distributed.utils_test import inc
 import pytest
 import skein
 
 from dask_yarn import YarnCluster
 from dask_yarn.core import _make_specification
-
-loop = loop  # silence flake8 f811
 
 APPNAME = 'dask-yarn-tests'
 
@@ -25,7 +24,7 @@ def conda_env():
     return envpath
 
 
-@pytest.fixture
+@pytest.fixture(scope='module')
 def skein_client():
     with skein.Client() as client:
         yield client
@@ -44,28 +43,41 @@ def check_is_shutdown(client, app_id, status='SUCCEEDED'):
     assert report.final_status == status
 
 
-def test_basic(skein_client, conda_env, loop):
+def test_basic(skein_client, conda_env):
     with YarnCluster(environment=conda_env,
                      worker_memory='512 MiB',
                      scheduler_memory='512 MiB',
                      name=APPNAME,
                      skein_client=skein_client) as cluster:
+        # Smoketest repr
+        repr(cluster)
+
+        # Scale up
         cluster.scale(2)
-        with Client(cluster, loop=loop) as client:
+
+        with Client(cluster) as client:
             future = client.submit(inc, 10)
             assert future.result() == 11
-
-            start = time.time()
-            while len(client.scheduler_info()['workers']) < 2:
-                time.sleep(0.1)
-                assert time.time() < start + 5
-
             client.get_versions(check=True)
+
+        # Check that 2 workers exist
+        start = time.time()
+        while len(cluster.workers()) != 2:
+            time.sleep(0.1)
+            assert time.time() < start + 5, "timeout cluster.scale(2)"
+
+        # Scale down
+        cluster.scale(1)
+
+        start = time.time()
+        while len(cluster.workers()) != 1:
+            time.sleep(0.1)
+            assert time.time() < start + 5, "timeout cluster.scale(1)"
 
     check_is_shutdown(skein_client, cluster.app_id)
 
 
-def test_from_specification(skein_client, conda_env, tmpdir, loop):
+def test_from_specification(skein_client, conda_env, tmpdir):
     spec = _make_specification(environment=conda_env,
                                worker_memory='512 MiB',
                                scheduler_memory='512 MiB',
@@ -75,8 +87,77 @@ def test_from_specification(skein_client, conda_env, tmpdir, loop):
         f.write(spec.to_yaml())
 
     with YarnCluster.from_specification(fn, skein_client=skein_client) as cluster:
-        with Client(cluster, loop=loop):
+        with Client(cluster):
             pass
+
+    check_is_shutdown(skein_client, cluster.app_id)
+
+
+def test_from_application_id(skein_client, conda_env):
+    with YarnCluster(environment=conda_env,
+                     worker_memory='512 MiB',
+                     scheduler_memory='512 MiB',
+                     name=APPNAME,
+                     skein_client=skein_client) as cluster:
+
+        # Connect to the application with the application id
+        cluster2 = YarnCluster.from_application_id(cluster.app_id, skein_client)
+
+        cluster2.scale(1)
+
+        start = time.time()
+        while len(cluster2.workers()) != 1:
+            time.sleep(0.1)
+            assert time.time() < start + 5, "timeout cluster.scale(1)"
+
+        del cluster2
+
+        # Cluster is still running, finalizer not run in cluster2
+        assert len(cluster.workers()) == 1
+
+    check_is_shutdown(skein_client, cluster.app_id)
+
+
+def test_from_current(skein_client, conda_env, monkeypatch, tmpdir):
+    # Not running in a container
+    with pytest.raises(ValueError) as exc:
+        YarnCluster.from_current()
+    assert str(exc.value) == "Not running inside a container"
+
+    with YarnCluster(environment=conda_env,
+                     worker_memory='512 MiB',
+                     scheduler_memory='512 MiB',
+                     name=APPNAME,
+                     skein_client=skein_client) as cluster:
+
+        # Patch environment so it looks like a container
+        container_id = 'container_1526134340424_0012_01_000005'
+        cont_dir = tmpdir.mkdir(container_id)
+        shutil.copyfile(skein_client.security.cert_path,
+                        str(cont_dir.join(".skein.crt")))
+        shutil.copyfile(skein_client.security.key_path,
+                        str(cont_dir.join(".skein.pem")))
+
+        for key, val in [('SKEIN_APPLICATION_ID', cluster.app_id),
+                         ('CONTAINER_ID', container_id),
+                         ('SKEIN_APPMASTER_ADDRESS', cluster.application_client.address),
+                         ('LOCAL_DIRS', str(tmpdir))]:
+            monkeypatch.setenv(key, val)
+
+        import skein.core
+        monkeypatch.setattr(skein.core, 'properties', skein.core.Properties())
+
+        cluster2 = YarnCluster.from_current()
+        assert cluster2.app_id == cluster.app_id
+        assert cluster2.scheduler_address == cluster.scheduler_address
+
+        # Smoketest method
+        cluster2.workers()
+
+        del cluster2
+
+        # Cluster is still running, finalizer not run in cluster2
+        cluster.workers()
 
     check_is_shutdown(skein_client, cluster.app_id)
 
@@ -138,18 +219,15 @@ def test_make_specification_errors():
     with dask.config.set({'yarn.environment': None}):
         with pytest.raises(ValueError) as info:
             _make_specification()
-
         assert 'conda-pack' in str(info.value)
 
     with pytest.raises(ValueError) as info:
         _make_specification(environment='foo.tar.gz', worker_memory=1234)
-
-        assert '1234 MiB' in str(info.value)
+    assert '1234 MiB' in str(info.value)
 
     with pytest.raises(ValueError) as info:
         _make_specification(environment='foo.tar.gz', scheduler_memory=1234)
-
-        assert '1234 MiB' in str(info.value)
+    assert '1234 MiB' in str(info.value)
 
 
 def test_environment_relative_paths(conda_env):


### PR DESCRIPTION
Adds two new ways to create `YarnCluster` objects:

- `YarnCluster.from_current` connects to an existing cluster from inside that cluster. Useful for having the client process also run inside a YARN container.

- `YarnCluster.from_application_id` connects to an existing cluster given the application id. Useful for connecting repeatedly to a long running cluster. Fixes #16.