### PR TITLE
Add deploy_mode

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -3,3 +3,4 @@ include = */dask_yarn/*
 omit =
     dask_yarn/_version.py
     dask_yarn/tests/*.py
+    dask_yarn/compat.py

--- a/dask_yarn/compat.py
+++ b/dask_yarn/compat.py
@@ -1,0 +1,12 @@
+from __future__ import absolute_import, division, print_function
+
+import sys
+
+PY2 = sys.version_info.major == 2
+
+if PY2:
+    from urlparse import urlparse
+    from backports import weakref
+else:
+    import weakref  # noqa
+    from urllib.parse import urlparse  # noqa

--- a/dask_yarn/tests/conftest.py
+++ b/dask_yarn/tests/conftest.py
@@ -10,9 +10,9 @@ import pytest
 
 @pytest.fixture(scope='session')
 def conda_env():
-    conda_pack = pytest.importorskip('conda_pack')
     envpath = 'dask-yarn-py%d%d.tar.gz' % sys.version_info[:2]
     if not os.path.exists(envpath):
+        conda_pack = pytest.importorskip('conda_pack')
         conda_pack.pack(output=envpath, verbose=True)
     return envpath
 

--- a/dask_yarn/yarn.yaml
+++ b/dask_yarn/yarn.yaml
@@ -6,7 +6,6 @@ yarn:
   name: dask                 # Application name
   queue: default             # Yarn queue to deploy to
   environment: null          # Path to conda packed environment
-  deploy-mode: remote        # Deploy mode to use. One of {remote, local}.
   tags: []                   # List of strings to tag applications
 
   scheduler:                 # Specifications of scheduler container

--- a/dask_yarn/yarn.yaml
+++ b/dask_yarn/yarn.yaml
@@ -6,6 +6,7 @@ yarn:
   name: dask                 # Application name
   queue: default             # Yarn queue to deploy to
   environment: null          # Path to conda packed environment
+  deploy-mode: remote        # Deploy mode to use. One of {remote, local}.
   tags: []                   # List of strings to tag applications
 
   scheduler:                 # Specifications of scheduler container

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,7 +7,9 @@ ignore =
     # Comparing types instead of isinstance
     E721,
     # Ambiguous variable names
-    E741
+    E741,
+    # Allow breaks after binary operators
+    W504
 max-line-length = 90
 
 [versioneer]


### PR DESCRIPTION
Adds a `deploy_mode` parameter, which specifies whether to run the
scheduler/client locally, or on a remote machine (default). This is
similar to spark's deploy-mode, except we use 'local' and 'remote'
instead of 'client' and 'cluster' respectively.

This parameter is useful for debugging, as it makes it easier to access
the dashboard (since the dashboard is running locally), as well as
easier to swap between having scripts run on a local machine vs remote.