### PR TITLE
Skein compatibility fix

### DIFF
--- a/dask_yarn/core.py
+++ b/dask_yarn/core.py
@@ -505,7 +505,7 @@ class YarnCluster(object):
         if workers is None:
             workers = self.workers()
         if n > len(workers):
-            self.application_client.scale(service='dask.worker', instances=n)
+            self.application_client.scale('dask.worker', n)
 
     def scale_down(self, workers):
         """Retire the selected workers.


### PR DESCRIPTION
The keyword name to `ApplicationClient.scale` changed in the recent
release. We remove specifying by keyword name to keep compatibility
between versions.