### PR TITLE
Fix uri_from_host_port import from cli.py

### DIFF
--- a/dask_yarn/cli.py
+++ b/dask_yarn/cli.py
@@ -14,7 +14,7 @@ from tornado import gen
 from tornado.ioloop import IOLoop, TimeoutError
 from distributed import Scheduler, Nanny
 from distributed.utils import ignoring
-from distributed.cli.utils import install_signal_handlers, uri_from_host_port
+from distributed.cli.utils import install_signal_handlers
 from distributed.proctitle import (enable_proctitle_on_children,
                                    enable_proctitle_on_current)
 
@@ -296,7 +296,7 @@ def scheduler():  # pragma: nocover
         limit = max(soft, hard // 2)
         resource.setrlimit(resource.RLIMIT_NOFILE, (limit, hard))
 
-    addr = uri_from_host_port('', None, 0)
+    addr = 'tcp://'
 
     loop = IOLoop.current()
 

--- a/dask_yarn/core.py
+++ b/dask_yarn/core.py
@@ -376,13 +376,14 @@ class YarnCluster(object):
             scheduler = self._local_cluster.scheduler
 
             scheduler_address = scheduler.address
-            try:
-                dashboard_port = scheduler.services['bokeh'].port
-            except KeyError:
-                dashboard_address = None
+            for k in ['dashboard', 'bokeh']:
+                if k in scheduler.services:
+                    dashboard_port = scheduler.services[k].port
+                    dashboard_host = urlparse(scheduler_address).hostname
+                    dashboard_address = 'http://%s:%d' % (dashboard_host, dashboard_port)
+                    break
             else:
-                dashboard_host = urlparse(scheduler_address).hostname
-                dashboard_address = 'http://%s:%d' % (dashboard_host, dashboard_port)
+                dashboard_address = None
 
             with submit_and_handle_failures(skein_client, spec) as app:
                 app.kv['dask.scheduler'] = scheduler_address.encode()


### PR DESCRIPTION
Hi there,

thank you very much for the great work, dask is really an amazingly well-thought library!

I was trying to follow the EMR tutorial [1] using the provided bootstrap script. However, the cluster would somehow silently fail. Looking into the logs, I was getting import errors for `uri_from_host_port` in `cli.py` which was confirmed by simply running `dask-yarn`. This is due to a combination of a loose dependency constraint in the bootstrap script and breaking changes introduced in `distributed 2.0.0`.

The first fix that worked for me was to simply change the bootstrap script to force `distributed==1.28.1`.  This is fine, but it forces the user to use `dask < 2.0.0`, which is sad.

The other fix that would work -- this PR! -- is to simply fix the import in `cli.py`. I'm not sure how much more would be needed to fully support `dask, distributed >= 2.0.0`, or if you are already working on it.

Please let me know if there are any additional changes required for this PR :)

[1] http://yarn.dask.org/en/latest/aws-emr.html