### PR TITLE
Set dashboard address during YarnCluster init

### DIFF
--- a/dask_yarn/core.py
+++ b/dask_yarn/core.py
@@ -297,9 +297,9 @@ class YarnCluster(object):
         the YARN documentation for more information.
     skein_client : skein.Client, optional
         The ``skein.Client`` to use. If not provided, one will be started.
-    dashboard_address : str, optional default: '0.0.0.0:8787'
+    dashboard_address : str, optional default: '0.0.0.0:0'
         The address and port of the dashboard when run in local mode
-    diagnostics_port : ( '', 8787), optional
+    diagnostics_port : ( '', 0), optional
         The address and port of the diagnostics port for versions 1.27.0
 
     Examples
@@ -390,11 +390,11 @@ class YarnCluster(object):
             # deploy_mode == 'local'
             if DISTRIBUTED_VERSION >= '1.27.0':
                 if dashboard_address is None:
-                    dashboard_address = '0.0.0.0:8787'
+                    dashboard_address = '0.0.0.0:0'
                 kwargs = {'dashboard_address': dashboard_address}
             else:
                 if diagnostics_port is None:
-                    diagnostics_port = ('', 8787)
+                    diagnostics_port = ('', 0)
                 kwargs = {'diagnostics_port': diagnostics_port}
             self._local_cluster = LocalCluster(n_workers=0,
                                                ip='0.0.0.0',

--- a/dask_yarn/core.py
+++ b/dask_yarn/core.py
@@ -338,7 +338,6 @@ class YarnCluster(object):
                                    queue=queue,
                                    tags=tags,
                                    user=user)
-        
 
         self._start_cluster(spec, skein_client, dashboard_address, diagnostics_port)
 
@@ -374,7 +373,11 @@ class YarnCluster(object):
         self._start_cluster(spec, skein_client)
         return self
 
-    def _start_cluster(self, spec, skein_client=None, dashboard_address=None, diagnostics_port=None):
+    def _start_cluster(self,
+                       spec,
+                       skein_client=None,
+                       dashboard_address=None,
+                       diagnostics_port=None):
         """Start the cluster and initialize state"""
 
         if 'dask.worker' not in spec.services:


### PR DESCRIPTION
I have been using dask-yarn for a few weeks and I think the most irritable part of using it is that the dashboard keeps jumping around when deployed in local mode.  Would it be possible to incorporate this change?

I would be glad to write some tests and update documentation if the general direction of the change is acceptable.

Thanks in advance for your consideration.