### PR TITLE
Update EMR bootstrap script

### DIFF
--- a/deployment_resources/aws-emr/bootstrap-dask
+++ b/deployment_resources/aws-emr/bootstrap-dask
@@ -95,24 +95,22 @@ conda update conda -y
 # We install a few packages by default, and allow users to extend this list
 # with a CLI flag:
 #
-# - dask-yarn >= 0.4.1, for deploying Dask on YARN.
+# - dask-yarn >= 0.7.0, for deploying Dask on YARN.
 # - pyarrow for working with hdfs, parquet, ORC, etc...
 # - s3fs for access to s3
-# - nomkl to minimize environment size
 # - conda-pack for packaging the environment for distribution
+# - ensure tornado 5, since tornado 6 doesn't work with jupyter-server-proxy
 # -----------------------------------------------------------------------------
 echo "Installing base packages"
 conda install \
--c defaults \
 -c conda-forge \
 -y \
 -q \
-python=3.6 \
-dask-yarn>=0.4.1 \
+dask-yarn>=0.7.0 \
 pyarrow \
 s3fs \
-nomkl \
 conda-pack \
+tornado=5 \
 $EXTRA_CONDA_PACKAGES
 
 
@@ -137,10 +135,12 @@ conda list
 # few things easier:
 #
 # - Configure the cluster's dashboard link to show the proxied version through
-#   jupyter nbserverproxy. This allows access to the dashboard with only an ssh
+#   jupyter-server-proxy. This allows access to the dashboard with only an ssh
 #   tunnel to the notebook.
 #
 # - Specify the pre-packaged python environment, so users don't have to
+#
+# - Set the default deploy-mode to local, so the dashboard proxying works
 #
 # - Specify the location of the native libhdfs library so pyarrow can find it
 #   on the workers and the client (if submitting applications).
@@ -154,6 +154,7 @@ distributed:
 
 yarn:
   environment: /home/hadoop/environment.tar.gz
+  deploy-mode: local
 
   worker:
     env:
@@ -185,19 +186,17 @@ fi
 #
 # - notebook: the Jupyter Notebook Server
 # - ipywidgets: used to provide an interactive UI for the YarnCluster objects
-# - nbserverproxy: used to proxy the dask dashboard through the notebook server
+# - jupyter-server-proxy: used to proxy the dask dashboard through the notebook server
 # -----------------------------------------------------------------------------
 if [[ "$JUPYTER" == "true" ]]; then
     echo "Installing Jupyter"
     conda install \
-    -c defaults \
     -c conda-forge \
     -y \
     -q \
-    python=3.6 \
     notebook \
     ipywidgets \
-    nbserverproxy
+    jupyter-server-proxy \
 fi
 
 

--- a/docs/source/aws-emr.rst
+++ b/docs/source/aws-emr.rst
@@ -126,8 +126,8 @@ environment (see :doc:`environments` for more information).
     from dask_yarn import YarnCluster
     from dask.distributed import Client
 
-    # Create a cluster in local deploy mode, to have access to the dashboard
-    cluster = YarnCluster(deploy_mode='local')
+    # Create a cluster
+    cluster = YarnCluster()
 
     # Connect to the cluster
     client = Client(cluster)
@@ -153,9 +153,8 @@ provided graphical interface to change the cluster size.
 .. image:: /_images/cluster-widget.png
     :alt: Cluster widget in a Jupyter Notebook
 
-If you used our bootstrap action, and start your cluster with
-``deploy_mode='local'``, the `dask dashboard`_ will also be available, and the
-link included in the cluster widget above.
+If you used our bootstrap action, the `dask dashboard`_ will also be available,
+and the link included in the cluster widget above.
 
 
 Shutdown the EMR Cluster


### PR DESCRIPTION
- Update the version requirements to recent dask-yarn release
- Require tornado version 5 (for now) due to bug in jupyter-server-proxy
- Use jupyter-server-proxy instead of nbserverproxy
- Configure `deploy-mode: local` in the configuration, instead of at
runtime. This makes it easy for users to just call `YarnCluster()` and
have everything work.