### PR TITLE
Add async support

### DIFF
--- a/continuous_integration/travis/install.sh
+++ b/continuous_integration/travis/install.sh
@@ -8,7 +8,6 @@ conda create -n test-environment \
     dask \
     distributed \
     flake8 \
-    black \
     nomkl \
     pytest \
     python=$1 \
@@ -16,7 +15,7 @@ conda create -n test-environment \
 
 source activate test-environment
 
-pip install conda-pack skein pytest-asyncio
+pip install conda-pack skein pytest-asyncio black
 
 cd ~/dask-yarn
 pip install -v --no-deps .

--- a/continuous_integration/travis/install.sh
+++ b/continuous_integration/travis/install.sh
@@ -11,7 +11,8 @@ conda create -n test-environment \
     nomkl \
     pytest \
     python=$1 \
-    pyyaml
+    pyyaml \
+    regex
 
 source activate test-environment
 

--- a/continuous_integration/travis/install.sh
+++ b/continuous_integration/travis/install.sh
@@ -16,7 +16,7 @@ conda create -n test-environment \
 
 source activate test-environment
 
-pip install conda-pack skein
+pip install conda-pack skein pytest-asyncio
 
 cd ~/dask-yarn
 pip install -v --no-deps .

--- a/dask_yarn/cli.py
+++ b/dask_yarn/cli.py
@@ -460,6 +460,7 @@ def worker(nthreads=None, memory_limit=None):  # pragma: nocover
         memory_limit=memory_limit,
         worker_port=0,
         nthreads=nthreads,
+        name=skein.properties.container_id,
     )
 
     async def cleanup():


### PR DESCRIPTION
Adds support for asynchronous cluster operations. If `asynchronous=True`
in the constructor, the following methods are async:

- Cluster creation (cluster object must be awaited, or an asynchronous
  context manager used)
- Cluster shutdown (either `cluster.shutdown` or `cluster.close`)
- Scaling (`cluster.scale`, `cluster.scale_up`, `cluster.scale_down`)
- Status queries (`cluster.workers`)