### PR TITLE
Support setting host/port/dashboard_address

### DIFF
--- a/dask_yarn/yarn.yaml
+++ b/dask_yarn/yarn.yaml
@@ -10,6 +10,10 @@ yarn:
   user: ''                   # The user to submit the application on behalf of,
                              # leave as empty string for current user.
 
+  host: "0.0.0.0"            # The scheduler host, when in deploy-mode=local
+  port: 0                    # The scheduler port, when in deploy-mode=local
+  dashboard-address: ":0"    # The dashboard address, when in deploy-mode=local
+
   scheduler:                 # Specifications of scheduler container
     vcores: 1
     memory: 2GiB


### PR DESCRIPTION
In local deploy mode, it can be useful to pre-specify the
host/port/dashboard_address for a cluster. This supports this, both as
constructor kwargs and in configuration. In remote deploy mode random
ports are still used.

Fixes #99
Supersedes #100 
Supersedes #85 
