### PR TITLE
URL is now a redirect that curl doesn't follow

### DIFF
--- a/deployment_resources/aws-emr/bootstrap-dask
+++ b/deployment_resources/aws-emr/bootstrap-dask
@@ -81,7 +81,7 @@ grep -q '"isMaster": true' /mnt/var/lib/info/instance.json \
 # 2. Install Miniconda
 # -----------------------------------------------------------------------------
 echo "Installing Miniconda"
-curl https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -o /tmp/miniconda.sh
+curl https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -o /tmp/miniconda.sh
 bash /tmp/miniconda.sh -b -p $HOME/miniconda
 rm /tmp/miniconda.sh
 echo -e '\nexport PATH=$HOME/miniconda/bin:$PATH' >> $HOME/.bashrc


### PR DESCRIPTION
repo.continuum.io is now a redirect.  Curl needs a `-L` flag or the correct url to work.