### PR TITLE
Add -L to the curl download of miniconda install script

### DIFF
--- a/deployment_resources/aws-emr/bootstrap-dask
+++ b/deployment_resources/aws-emr/bootstrap-dask
@@ -81,7 +81,7 @@ grep -q '"isMaster": true' /mnt/var/lib/info/instance.json \
 # 2. Install Miniconda
 # -----------------------------------------------------------------------------
 echo "Installing Miniconda"
-curl https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -o /tmp/miniconda.sh
+curl -L https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -o /tmp/miniconda.sh
 bash /tmp/miniconda.sh -b -p $HOME/miniconda
 rm /tmp/miniconda.sh
 echo -e '\nexport PATH=$HOME/miniconda/bin:$PATH' >> $HOME/.bashrc


### PR DESCRIPTION
I had failures in the EMR boostrap action using the script as-is. After some tinkering, I realized that curl on line 84  was failing with a generated file size of 0. Tests on my personal machine replicated the problem, which I solved by adding the `-L` (follow redirects) option to it.