### PR TITLE
fea/update-worker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: required
 dist: trusty
 os: linux
 python:
-  - "3.8"
+  - "3.7"
 
 services:
   - docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: required
 dist: trusty
 os: linux
 python:
-  - "3.7"
+  - "3.6"
 
 services:
   - docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: required
 dist: trusty
 os: linux
 python:
-  - "3.6"
+  - "3.8"
 
 services:
   - docker

--- a/dask_yarn/cli.py
+++ b/dask_yarn/cli.py
@@ -454,7 +454,7 @@ def worker(nthreads=None, memory_limit=None):  # pragma: nocover
     worker_class = os.environ.get("worker_class", "dask.distributed.Nanny")
     options = os.environ.get("worker_options", str(base64.b64encode(b"{}")))
 
-    # options come in a string
+    # options come in as a string
     # encode string as bytes
     # decode base64
     # load with json
@@ -477,6 +477,8 @@ def worker(nthreads=None, memory_limit=None):  # pragma: nocover
     ]
     print(command)
     subprocess.check_call(command)
+
+    install_signal_handlers(loop)
 
 
 @subcommand(

--- a/dask_yarn/cli.py
+++ b/dask_yarn/cli.py
@@ -12,7 +12,7 @@ from urllib.parse import urlparse
 import skein
 from skein.utils import format_table, humanize_timedelta
 from tornado.ioloop import IOLoop, TimeoutError
-from distributed import Scheduler, Nanny
+from distributed import Scheduler
 from distributed.cli.utils import install_signal_handlers
 from distributed.proctitle import (
     enable_proctitle_on_children,
@@ -472,7 +472,7 @@ def worker(nthreads=None, memory_limit=None):  # pragma: nocover
         % json.dumps(
             {
                 "cls": worker_class,
-                "opts": {"name": skein.properties.container_id, **worker_options,},
+                "opts": {"name": skein.properties.container_id, **worker_options},
             }
         ),
     ]

--- a/dask_yarn/cli.py
+++ b/dask_yarn/cli.py
@@ -451,11 +451,11 @@ def worker(nthreads=None, memory_limit=None):  # pragma: nocover
     app_client = skein.ApplicationClient.from_current()
 
     scheduler = app_client.kv.wait("dask.scheduler").decode()
-    worker_class = os.environ.get('worker_class', "dask.distributed.Nanny")
-    options = os.environ.get('worker_options', str(base64.b64encode(b'{}')))
+    worker_class = os.environ.get("worker_class", "dask.distributed.Nanny")
+    options = os.environ.get("worker_options", str(base64.b64encode(b"{}")))
 
     # options come in a string
-    # enconde string as bytes
+    # encode string as bytes
     # decode base64
     # load with json
     options = base64.b64decode(options.encode())
@@ -478,6 +478,7 @@ def worker(nthreads=None, memory_limit=None):  # pragma: nocover
     ]
     print(command)
     subprocess.check_call(command)
+
 
 @subcommand(
     services.subs,

--- a/dask_yarn/cli.py
+++ b/dask_yarn/cli.py
@@ -477,6 +477,7 @@ def worker(nthreads=None, memory_limit=None):  # pragma: nocover
     ]
     print(command)
     subprocess.check_call(command)
+    loop = IOLoop.current()
 
     install_signal_handlers(loop)
 

--- a/dask_yarn/cli.py
+++ b/dask_yarn/cli.py
@@ -459,11 +459,10 @@ def worker(nthreads=None, memory_limit=None):  # pragma: nocover
     # decode base64
     # load with json
     options = base64.b64decode(options.encode())
-    print(options)
     worker_options.update(json.loads(options))
     print(worker_options)
     command = [
-        "python",
+        sys.executable,
         "-m",
         "distributed.cli.dask_spec",
         scheduler,

--- a/dask_yarn/cli.py
+++ b/dask_yarn/cli.py
@@ -1,7 +1,9 @@
 import argparse
 import os
+import base64
 import shutil
 import subprocess
+import json
 import sys
 import tempfile
 from contextlib import contextmanager
@@ -440,43 +442,42 @@ def scheduler():  # pragma: nocover
     ),
 )
 def worker(nthreads=None, memory_limit=None):  # pragma: nocover
-    enable_proctitle_on_current()
-    enable_proctitle_on_children()
-
     if memory_limit is None:
         memory_limit = int(skein.properties.container_resources.memory * 2 ** 20)
     if nthreads is None:
         nthreads = skein.properties.container_resources.vcores
 
+    worker_options = dict(memory_limit=memory_limit, nthreads=nthreads)
     app_client = skein.ApplicationClient.from_current()
 
     scheduler = app_client.kv.wait("dask.scheduler").decode()
+    worker_class = os.environ.get('worker_class', "dask.distributed.Nanny")
+    options = os.environ.get('worker_options', str(base64.b64encode(b'{}')))
 
-    loop = IOLoop.current()
-
-    worker = Nanny(
+    # options come in a string
+    # enconde string as bytes
+    # decode base64
+    # load with json
+    options = base64.b64decode(options.encode())
+    print(options)
+    worker_options.update(json.loads(options))
+    print(worker_options)
+    command = [
+        "python",
+        "-m",
+        "distributed.cli.dask_spec",
         scheduler,
-        loop=loop,
-        memory_limit=memory_limit,
-        worker_port=0,
-        nthreads=nthreads,
-        name=skein.properties.container_id,
-    )
-
-    async def cleanup():
-        await worker.close(timeout=2)
-
-    install_signal_handlers(loop, cleanup=cleanup)
-
-    async def run():
-        await worker
-        await worker.finished()
-
-    try:
-        loop.run_sync(run)
-    except (KeyboardInterrupt, TimeoutError):
-        pass
-
+        "--spec",
+        "%s"  # in yaml double single quotes escape the single quote
+        % json.dumps(
+            {
+                "cls": worker_class,
+                "opts": {"name": skein.properties.container_id, **worker_options,},
+            }
+        ),
+    ]
+    print(command)
+    subprocess.check_call(command)
 
 @subcommand(
     services.subs,

--- a/dask_yarn/core.py
+++ b/dask_yarn/core.py
@@ -528,7 +528,9 @@ class YarnCluster(object):
         self.spec = spec
         self.application_client = application_client
         self._scheduler_kwargs = _make_scheduler_kwargs(
-            host=host, port=port, dashboard_address=dashboard_address,
+            host=host,
+            port=port,
+            dashboard_address=dashboard_address,
         )
         self._scheduler = None
         self.scheduler_info = {}
@@ -616,7 +618,10 @@ class YarnCluster(object):
         if self.spec is not None:
             # Start a new cluster
             if "dask.scheduler" not in self.spec.services:
-                self._scheduler = Scheduler(loop=self.loop, **self._scheduler_kwargs,)
+                self._scheduler = Scheduler(
+                    loop=self.loop,
+                    **self._scheduler_kwargs,
+                )
                 await self._scheduler
             else:
                 self._scheduler = None
@@ -814,7 +819,8 @@ class YarnCluster(object):
     async def _scale_up(self, n):
         if n > len(self._requested):
             containers = await self.loop.run_in_executor(
-                None, lambda: self.application_client.scale("dask.worker", n),
+                None,
+                lambda: self.application_client.scale("dask.worker", n),
             )
             self._requested.update(c.id for c in containers)
 
@@ -830,7 +836,8 @@ class YarnCluster(object):
                     pass
 
         await self.loop.run_in_executor(
-            None, _kill_containers,
+            None,
+            _kill_containers,
         )
 
     async def _scale(self, n):

--- a/dask_yarn/core.py
+++ b/dask_yarn/core.py
@@ -200,6 +200,7 @@ def _make_specification(**kwargs):
     worker_options = base64.b64encode(json.dumps(worker_options).encode()).decode()
     worker_env["worker_options"] = worker_options
     worker_vcores = lookup(kwargs, "worker_vcores", "yarn.worker.vcores")
+    worker_gpus = lookup(kwargs, "worker_gpus", "yarn.worker.gpus")
     worker_memory = parse_memory(
         lookup(kwargs, "worker_memory", "yarn.worker.memory"), "worker"
     )
@@ -210,13 +211,16 @@ def _make_specification(**kwargs):
 
     if deploy_mode == "remote":
         scheduler_vcores = lookup(kwargs, "scheduler_vcores", "yarn.scheduler.vcores")
+        scheduler_gpus = lookup(kwargs, "scheduler_gpus", "yarn.scheduler.gpus")
         scheduler_memory = parse_memory(
             lookup(kwargs, "scheduler_memory", "yarn.scheduler.memory"), "scheduler"
         )
 
         services["dask.scheduler"] = skein.Service(
             instances=1,
-            resources=skein.Resources(vcores=scheduler_vcores, memory=scheduler_memory),
+            resources=skein.Resources(
+                vcores=scheduler_vcores, memory=scheduler_memory, gpus=scheduler_gpus
+            ),
             max_restarts=0,
             files=files,
             script=build_script("services scheduler"),
@@ -227,7 +231,9 @@ def _make_specification(**kwargs):
 
     services["dask.worker"] = skein.Service(
         instances=n_workers,
-        resources=skein.Resources(vcores=worker_vcores, memory=worker_memory),
+        resources=skein.Resources(
+            vcores=worker_vcores, memory=worker_memory, gpus=worker_gpus
+        ),
         max_restarts=worker_restarts,
         depends=worker_depends,
         files=files,
@@ -251,6 +257,7 @@ def _make_submit_specification(script, args=(), **kwargs):
         # deploy_mode == 'remote'
         client_vcores = lookup(kwargs, "client_vcores", "yarn.client.vcores")
         client_memory = lookup(kwargs, "client_memory", "yarn.client.memory")
+        client_gpus = lookup(kwargs, "client_gpus", "yarn.client.gpus")
         client_env = lookup(kwargs, "client_env", "yarn.client.env")
         client_memory = parse_memory(client_memory, "client")
 
@@ -259,7 +266,9 @@ def _make_submit_specification(script, args=(), **kwargs):
 
         spec.services["dask.client"] = skein.Service(
             instances=1,
-            resources=skein.Resources(vcores=client_vcores, memory=client_memory),
+            resources=skein.Resources(
+                vcores=client_vcores, memory=client_memory, gpus=client_gpus
+            ),
             max_restarts=0,
             depends=["dask.scheduler"],
             files=files,
@@ -310,8 +319,12 @@ class YarnCluster(object):
     worker_env : dict, optional
         A mapping of environment variables to their values. These will be set
         in the worker containers before starting the dask workers.
+    worker_gpus : int, options
+        The number of gpus to allocate per worker
     scheduler_vcores : int, optional
         The number of virtual cores to allocate per scheduler.
+    scheduler_gpus : int, options
+        The number of gpus to allocate per scheduler
     scheduler_memory : str, optional
         The amount of memory to allocate to the scheduler. Accepts a unit
         suffix (e.g. '2 GiB' or '4096 MiB'). Will be rounded up to the nearest
@@ -364,7 +377,9 @@ class YarnCluster(object):
         worker_env=None,
         worker_class=None,
         worker_options=None,
+        worker_gpus=None,
         scheduler_vcores=None,
+        scheduler_gpus=None,
         scheduler_memory=None,
         deploy_mode=None,
         name=None,
@@ -388,7 +403,9 @@ class YarnCluster(object):
             worker_env=worker_env,
             worker_class=worker_class,
             worker_options=worker_options,
+            worker_gpus=worker_gpus,
             scheduler_vcores=scheduler_vcores,
+            scheduler_gpus=scheduler_gpus,
             scheduler_memory=scheduler_memory,
             deploy_mode=deploy_mode,
             name=name,

--- a/dask_yarn/tests/test_core.py
+++ b/dask_yarn/tests/test_core.py
@@ -233,11 +233,12 @@ def test_configuration(deploy_mode):
                 "count": 1,
                 "vcores": 1,
                 "restarts": -1,
+                "gpus": 2,
                 "env": {"foo": "bar"},
                 "worker_class": "abc",
                 "worker_options": {"FOO": "BAZ"},
             },
-            "scheduler": {"memory": "1234 MiB", "vcores": 1},
+            "scheduler": {"memory": "1234 MiB", "vcores": 1, "gpus": 0},
             "host": "0.0.0.0",
             "port": 8786,
             "dashboard_address": ":8787",
@@ -251,6 +252,7 @@ def test_configuration(deploy_mode):
         assert spec.queue == "myqueue"
         assert spec.tags == {"a", "b", "c"}
         assert spec.services["dask.worker"].resources.memory == 1234
+        assert spec.services["dask.worker"].resources.gpus == 2
         assert spec.services["dask.worker"].env == {
             "foo": "bar",
             "worker_class": "abc",
@@ -259,6 +261,7 @@ def test_configuration(deploy_mode):
 
         if deploy_mode == "remote":
             assert spec.services["dask.scheduler"].resources.memory == 1234
+            assert spec.services["dask.scheduler"].resources.gpus == 0
         else:
             assert "dask.scheduler" not in spec.services
 

--- a/dask_yarn/tests/test_core.py
+++ b/dask_yarn/tests/test_core.py
@@ -35,9 +35,10 @@ def test_basic(deploy_mode, skein_client, conda_env):
         skein_client=skein_client,
         dashboard_address=":8787",
         port=8786,
+        worker_options={"resources": {"FOO": "BAZ"}},
+        worker_class="dask.distributed.Nanny",
     ) as cluster:
         # Smoketest repr
-        repr(cluster)
 
         if bokeh_installed:
             assert cluster.dashboard_link is not None
@@ -54,6 +55,8 @@ def test_basic(deploy_mode, skein_client, conda_env):
             future = client.submit(inc, 10)
             assert future.result() == 11
             client.get_versions(check=True)
+            resource_tags = client.run(lambda dask_worker: dask_worker.total_resources)
+            assert {'FOO': 'BAZ'} in list(resource_tags.values())
 
         # Check that 2 workers exist
         start = time.time()
@@ -231,6 +234,8 @@ def test_configuration(deploy_mode):
                 "vcores": 1,
                 "restarts": -1,
                 "env": {"foo": "bar"},
+                "worker_class": "abc",
+                "worker_options": {"FOO": "BAZ"}
             },
             "scheduler": {"memory": "1234 MiB", "vcores": 1},
             "host": "0.0.0.0",
@@ -246,7 +251,8 @@ def test_configuration(deploy_mode):
         assert spec.queue == "myqueue"
         assert spec.tags == {"a", "b", "c"}
         assert spec.services["dask.worker"].resources.memory == 1234
-        assert spec.services["dask.worker"].env == {"foo": "bar"}
+        assert spec.services["dask.worker"].env == {'foo': 'bar', 'worker_class': 'abc', 'worker_options': 'eyJGT08iOiAiQkFaIn0='}
+
         if deploy_mode == "remote":
             assert spec.services["dask.scheduler"].resources.memory == 1234
         else:

--- a/dask_yarn/tests/test_core.py
+++ b/dask_yarn/tests/test_core.py
@@ -56,7 +56,7 @@ def test_basic(deploy_mode, skein_client, conda_env):
             assert future.result() == 11
             client.get_versions(check=True)
             resource_tags = client.run(lambda dask_worker: dask_worker.total_resources)
-            assert {'FOO': 'BAZ'} in list(resource_tags.values())
+            assert {"FOO": "BAZ"} in list(resource_tags.values())
 
         # Check that 2 workers exist
         start = time.time()
@@ -235,7 +235,7 @@ def test_configuration(deploy_mode):
                 "restarts": -1,
                 "env": {"foo": "bar"},
                 "worker_class": "abc",
-                "worker_options": {"FOO": "BAZ"}
+                "worker_options": {"FOO": "BAZ"},
             },
             "scheduler": {"memory": "1234 MiB", "vcores": 1},
             "host": "0.0.0.0",
@@ -251,7 +251,11 @@ def test_configuration(deploy_mode):
         assert spec.queue == "myqueue"
         assert spec.tags == {"a", "b", "c"}
         assert spec.services["dask.worker"].resources.memory == 1234
-        assert spec.services["dask.worker"].env == {'foo': 'bar', 'worker_class': 'abc', 'worker_options': 'eyJGT08iOiAiQkFaIn0='}
+        assert spec.services["dask.worker"].env == {
+            "foo": "bar",
+            "worker_class": "abc",
+            "worker_options": "eyJGT08iOiAiQkFaIn0=",
+        }
 
         if deploy_mode == "remote":
             assert spec.services["dask.scheduler"].resources.memory == 1234

--- a/dask_yarn/yarn.yaml
+++ b/dask_yarn/yarn.yaml
@@ -24,6 +24,8 @@ yarn:
     count: 0                # Number of workers to start on initialization
     restarts: -1            # Allowed number of restarts, -1 for unlimited
     env: {}                 # A map of environment variables to set on the worker
+    worker_class: "dask.distributed.Nanny" # The kind of worker to launch
+    worker_options: {}      # A map of options to pass to the worker
 
   client:                   # Specification of client container
     vcores: 1

--- a/dask_yarn/yarn.yaml
+++ b/dask_yarn/yarn.yaml
@@ -17,6 +17,7 @@ yarn:
   scheduler:                 # Specifications of scheduler container
     vcores: 1
     memory: 2GiB
+    gpus: 0                 # Number of GPUs requested
 
   worker:                   # Specifications of worker containers
     vcores: 1
@@ -24,10 +25,12 @@ yarn:
     count: 0                # Number of workers to start on initialization
     restarts: -1            # Allowed number of restarts, -1 for unlimited
     env: {}                 # A map of environment variables to set on the worker
+    gpus: 0                 # Number of GPUs requested
     worker_class: "dask.distributed.Nanny" # The kind of worker to launch
     worker_options: {}      # A map of options to pass to the worker
 
   client:                   # Specification of client container
     vcores: 1
     memory: 2GiB
+    gpus: 0                 # Number of GPUs requested
     env: {}                 # A map of environment variables ot set on the client

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-dask>=2.6.0
-distributed>=2.6.0
+dask>=2021.1.0
+distributed>=2021.1.0
 skein>=0.8.0
 grpcio>=1.14.0

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     packages=["dask_yarn"],
     include_package_data=True,
     install_requires=install_requires,
-    python_requires=">=3.5",
+    python_requires=">=3.7",
     entry_points="""
         [console_scripts]
         dask-yarn=dask_yarn.cli:main


### PR DESCRIPTION
PR replaces usage of `Nanny` in the worker with `dask_spec`.  Using `dask_spec` users can can define `worker_classes` and `worker_options` in an effort to mimic the style of deployment leveraged in dask-cloudprovider