### PR TITLE
add client.shutdown() and cluster.shutdown() to quickstart code snippet

### DIFF
--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -114,6 +114,12 @@ defined in the :doc:`configuration`.
     # Connect to the cluster
     client = Client(cluster)
 
+    # Do some work here
+
+    # Shutdown client and cluster (alternatively use context-manager as shown below):
+    client.shutdown()
+    cluster.shutdown()
+
 
 By default no workers are started on cluster creation. To change the number of
 workers, use the :func:`YarnCluster.scale` method. When scaling up, new workers


### PR DESCRIPTION
I struggled about 2 hours why submitted Dask application wouldn't stop in YARN until I finally realized in the buttom of the quickstart section it was described that you also have to shutdown the cluster and not only the client.

I added this information in the first code snippet, which is the entry point for the reader in my opinion and slightly improves the documentation.

Thanks for your work on this library.

Best Patrik