### PR TITLE
Add dask-ctl support

### DIFF
--- a/continuous_integration/travis/install.sh
+++ b/continuous_integration/travis/install.sh
@@ -8,6 +8,7 @@ conda create -n test-environment -c conda-forge \
     cryptography \
     dask \
     distributed \
+    dask-ctl \
     flake8 \
     nomkl \
     pytest \

--- a/dask_yarn/core.py
+++ b/dask_yarn/core.py
@@ -169,7 +169,8 @@ def _make_specification(**kwargs):
 
     name = lookup(kwargs, "name", "yarn.name")
     queue = lookup(kwargs, "queue", "yarn.queue")
-    tags = lookup(kwargs, "tags", "yarn.tags").append("dask-yarn")
+    tags = lookup(kwargs, "tags", "yarn.tags")
+    tags.append("dask-yarn")
     user = lookup(kwargs, "user", "yarn.user")
 
     environment = lookup(kwargs, "environment", "yarn.environment")
@@ -982,7 +983,7 @@ class YarnCluster(object):
             return _widget_status_template % (n_workers, cores, format_bytes(memory))
 
     def _widget(self):
-        """ Create IPython widget for display within a notebook """
+        """Create IPython widget for display within a notebook"""
         try:
             return self._cached_widget
         except AttributeError:

--- a/dask_yarn/core.py
+++ b/dask_yarn/core.py
@@ -169,8 +169,7 @@ def _make_specification(**kwargs):
 
     name = lookup(kwargs, "name", "yarn.name")
     queue = lookup(kwargs, "queue", "yarn.queue")
-    tags = lookup(kwargs, "tags", "yarn.tags")
-    tags.add("dask-yarn")
+    tags = lookup(kwargs, "tags", "yarn.tags").append("dask-yarn")
     user = lookup(kwargs, "user", "yarn.user")
 
     environment = lookup(kwargs, "environment", "yarn.environment")

--- a/dask_yarn/tests/test_core.py
+++ b/dask_yarn/tests/test_core.py
@@ -254,7 +254,7 @@ def test_configuration(deploy_mode):
         assert spec.name == "dask-yarn-tests"
         assert spec.user == "alice"
         assert spec.queue == "myqueue"
-        assert spec.tags == {"a", "b", "c"}
+        assert spec.tags == {"a", "b", "c", "dask-yarn"}  # dask-yarn is a default tag
         assert spec.services["dask.worker"].resources.memory == 1234
         assert spec.services["dask.worker"].resources.gpus == 2
         assert spec.services["dask.worker"].env == {
@@ -586,7 +586,7 @@ async def test_from_name(skein_client, conda_env):
         worker_options={"resources": {"FOO": "BAZ"}},
         worker_class="dask.distributed.Nanny",
     )
-    await cluster.scale(1)
+    cluster.scale(1)
     name = cluster.application_client.name
 
     # Check cluster listed in discovery

--- a/dask_yarn/tests/test_core.py
+++ b/dask_yarn/tests/test_core.py
@@ -587,7 +587,7 @@ async def test_from_name(skein_client, conda_env):
         worker_class="dask.distributed.Nanny",
     )
     cluster.scale(1)
-    name = cluster.application_client.name
+    name = cluster.app_id
 
     # Check cluster listed in discovery
     discovery = "yarncluster"

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,8 @@ setup(
     entry_points="""
         [console_scripts]
         dask-yarn=dask_yarn.cli:main
+        [dask_cluster_discovery]
+        yarncluster=dask_yarn.core:discover
       """,
     zip_safe=False,
 )


### PR DESCRIPTION
Given that `dask-yarn` already allows for folks to connect/disconnect from running clusters it seemed like a quick win to add `dask-ctl` support.

I don't have a local dev environment for this so may debug in CI.