### PR TITLE
Update docs theme for rebranding

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,12 +1,12 @@
 repos:
 - repo: https://github.com/psf/black
-  rev: stable
+  rev: 22.3.0
   hooks:
     - id: black
-      language_version: python3.7
+      language_version: python3.8
 
 - repo: https://gitlab.com/pycqa/flake8
-  rev: 3.7.9
+  rev: 3.9.2
   hooks:
     - id: flake8
-      language_version: python3.7
+      language_version: python3.8

--- a/docs/requirements-docs.txt
+++ b/docs/requirements-docs.txt
@@ -1,4 +1,4 @@
 numpydoc
 sphinx
 sphinxcontrib.autoprogram
-dask_sphinx_theme>=1.1.0
+dask-sphinx-theme>=3.0.0

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -19,4 +19,6 @@ html_theme = "dask_sphinx_theme"
 templates_path = ["_templates"]
 html_static_path = ["_static"]
 htmlhelp_basename = "dask-yarndoc"
-pygments_style = "default"
+# Commenting this out for now, if we register dask pygments,
+# then eventually this line can be:
+# pygments_style = "dask"


### PR DESCRIPTION
On Monday, June 6th, dask.org will go live with a new design (see https://github.com/dask/community/issues/220). This PR is in preparation for the theme update for `dask-sphinx-theme` and can be merged in *after* https://github.com/dask/dask-sphinx-theme/pull/67 on Monday.

cc @jacobtomlinson @jsignell